### PR TITLE
Ignore empty lines in server_list

### DIFF
--- a/include/hcl/common/configuration_manager.h
+++ b/include/hcl/common/configuration_manager.h
@@ -90,18 +90,20 @@ namespace hcl {
               std::string server_node_name;
               int count;
               while (getline(file, file_line)) {
-                  size_t split_loc = file_line.find(':');  // split to node and net
-                  if (split_loc != std::string::npos) {
-                      server_node_name = file_line.substr(0, split_loc);
-                      count = atoi(file_line.substr(split_loc+1, std::string::npos).c_str());
-                  } else {
-                      // no special network
-                      server_node_name = file_line;
-                      count = 1;
-                  }
-                  // server list is list of network interfaces
-                  for(int i=0;i<count;++i){
-                      SERVER_LIST.emplace_back(server_node_name);
+                  if (!file_line.empty()) {
+                      size_t split_loc = file_line.find(':');  // split to node and net
+                      if (split_loc != std::string::npos) {
+                          server_node_name = file_line.substr(0, split_loc);
+                          count = atoi(file_line.substr(split_loc+1, std::string::npos).c_str());
+                      } else {
+                          // no special network
+                          server_node_name = file_line;
+                          count = 1;
+                      }
+                      // server list is list of network interfaces
+                      for(int i=0;i<count;++i){
+                          SERVER_LIST.emplace_back(server_node_name);
+                      }
                   }
               }
           } else {


### PR DESCRIPTION
The `ConfigurationManager` was counting empty lines in the `server_list` file as extra servers. Here we just ignore them.